### PR TITLE
Test Suite and ISO8601 Fix

### DIFF
--- a/lib/DBR/Config/ScanDB.pm
+++ b/lib/DBR/Config/ScanDB.pm
@@ -207,7 +207,11 @@ sub update_fields{
 	    if(defined $extra){
 		  $is_signed = ($extra =~ / unsigned/i)?0:1;
 		  $is_signed = 0 if $type =~ /unsigned/i; #Lame... SQLite sometimes returns the data type as 'int unsigned'
-	    }
+	    } else {
+                # SQLite has no unsigned types, or really types at all.  fake it by pulling a sign flag out of the type name
+                $is_signed = 1;
+                $is_signed = 0 if ($type =~ /UNSIGNED/i);
+            }
 	    $type =~ /^\s+|\s+$/g;
 	    ($type) = split (/\s+/,$type);
 	    my $typeid = DBR::Config::Field->get_type_id($type) or die( "Invalid type '$type'" );

--- a/lib/DBR/Config/Trans/UnixTime.pm
+++ b/lib/DBR/Config/Trans/UnixTime.pm
@@ -132,7 +132,13 @@ sub format  {
       return strftime ($_[1], localtime($_[0][0]));
 }
 
-sub iso8601{ shift->format('%Y-%m-%dT%H:%M:%S%z') }
+sub iso8601 {
+    local($ENV{TZ}) = ${$_[0][1]}; tzset();
+    my @lt = localtime($_[0][0]);
+    my $tz = strftime("%z", @lt);
+    $tz =~ s/(\d{2})(\d{2})/$1:$2/;
+    return strftime ('%Y-%m-%dT%H:%M:%S', @lt) . $tz;
+}
 
 sub midnight{
       my $self = shift;


### PR DESCRIPTION
Fixed signed integer bug in SQLITE test suite.

Added colon to ISO8601-formatted string for compatibility with Firefox/Safari.